### PR TITLE
fix(dockerfile): improvement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM node:6.10.2
+FROM node:6.10.2-alpine
 
-# Install yarn
-
-# RUN npm install -g yarn
+# File Author / Maintainer
+MAINTAINER Hernan Rajchert
 
 # First copy the yarn.lock to install stuff and benefit from the layer cache
 COPY ["package.json", "yarn.lock", "/usr/src/"]
@@ -20,4 +19,4 @@ COPY [".", "/usr/src/"]
 RUN npm run build
 
 # Tell docker what to run as default
-CMD npm start
+ENTRYPOINT ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Features
 
 ### Docker
 
-If the node app you are trying to build is intended to be a service of some sort (micro or monolithic) you may want to guarantee that it runs in reliable environment. Using Docker we can specify the version of `os`, `node` and others to reduce the difference between dev, prod and CI environment.
+If the node app you are trying to build is intended to be a service of some sort (micro or monolithic) you may want to guarantee that it runs in reliable environment. Using Docker we can specify the version of `os`, `node` and others to reduce the difference between dev, prod and ci environments.
 
 If you want to learn more about Docker you can try [this course (in spanish)](https://www.acamica.com/cursos/128/introduccion-a-docker). To remove docker from the project just delete the `Dockerfile`.
 
 To use docker with this starter project, first create your images with the following command
 
 ```console
-docker build -t tyno:0.0.1 .
+docker build -t myapp:0.0.1 .
 ```
 
-where `-t tyno:0.0.1` tags the image as `tyno` in the specific version. Then run an instance of your image like this
+where `-t myapp:0.0.1` tags the image as `myapp` in the specific version. Then run an instance of your image like this
 
 ```console
-docker run --name myapp tyno
+docker run myapp
 ```
 
 Notice that the `Dockerfile` is built in order to take advantage of the `Docker layers`, if you modify the code in the src folder it won't run `yarn install`, but if you change the `package.json` or `yarn.lock` it will.

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ Features
 * TSlint before commit
 * GIT messages validator using format like `feat(general): Some description`
 * Reliable package management using [yarn](https://yarnpkg.com/en/)
-* Homogeneous service enviroment using [Docker](https://www.docker.com/)
+* Homogeneous service environment using [Docker](https://www.docker.com/)
 * [Editor config](http://editorconfig.org/) for editors that supports it like Visual Code
 
 ### Docker
 
-If the node app you are trying to build is intended to be a service of some sort (micro or monolithic) you may want to guarantee that it runs in reliable enviroment. Using Docker we can specify the version of `os`, `node` and others to reduce the difference between dev, prod and ci enviroments.
+If the node app you are trying to build is intended to be a service of some sort (micro or monolithic) you may want to guarantee that it runs in reliable environment. Using Docker we can specify the version of `os`, `node` and others to reduce the difference between dev, prod and CI environment.
 
 If you want to learn more about Docker you can try [this course (in spanish)](https://www.acamica.com/cursos/128/introduccion-a-docker). To remove docker from the project just delete the `Dockerfile`.
 
 To use docker with this starter project, first create your images with the following command
 
 ```console
-docker build -t myapp:0.0.1 .
+docker build -t tyno:0.0.1 .
 ```
 
-where `-t myapp:0.0.1` tags the image as `myapp` in the specific version. Then run an instance of your image like this
+where `-t tyno:0.0.1` tags the image as `tyno` in the specific version. Then run an instance of your image like this
 
 ```console
-docker run myapp
+docker run --name myapp tyno
 ```
 
 Notice that the `Dockerfile` is built in order to take advantage of the `Docker layers`, if you modify the code in the src folder it won't run `yarn install`, but if you change the `package.json` or `yarn.lock` it will.


### PR DESCRIPTION
Cambie el imagen base del Dockerfile a la version `alpine` que se basa en https://alpinelinux.org/ una version muy liviana y usada en todos los contenedores oficiales.  De esta manera se puede reutilizar esta parte del contenedor.